### PR TITLE
Revise request subscriptions to make them more flexible

### DIFF
--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -13,10 +13,14 @@ module Conduit
     has_many :responses,   dependent: :destroy
     has_many :subscriptions, autosave: true
 
+    has_many   :children, class_name: 'Conduit::Request', foreign_key: :parent_id
+    belongs_to :parent,   class_name: 'Conduit::Request'
+
     # Validations
 
     validates :driver, presence: true
     validates :action, presence: true
+    validate  :assure_supported_driver_and_action
 
     # Hooks
 
@@ -79,7 +83,38 @@ module Conduit
       subscriptions.map(&:subscriber)
     end
 
+    def callback_url=(callback_url)
+      options.merge!(callback_url: callback_url)
+      attribute_will_change!(:options)
+    end
+
+    def callback_url
+      options[:callback_url]
+    end
+
+    def subscribe(responder_type, **responder_options)
+      self.subscriptions.create(responder_type: responder_type.to_s, responder_options: responder_options)
+    end
+
     private
+
+      def conduit_driver
+        @conduit_driver ||= Conduit::Util.find_driver(driver)
+      end
+
+      def assure_supported_driver_and_action
+        unless conduit_driver.present?
+          errors.add(:driver, "#{driver} is not a supported driver")
+          return false
+        end
+
+        unless conduit_driver.actions.include?(action.to_sym)
+          errors.add(:action, "not supported by the #{driver} driver")
+          return false
+        end
+      end
+
+
 
       # Set some default values
       #
@@ -106,11 +141,9 @@ module Conduit
       #
       def notify_subscribers
         return unless last_response = responses.last
-        subscribers.each do |subscriber|
-          next unless subscriber.respond_to?(:after_conduit_update)
-
-          subscriber.after_conduit_update(action,
-            last_response.parsed_content)
+        subscriptions.each do |subscription|
+          subscription.handle_conduit_response(action, last_response)
+          # What to do if one of them fail? Keep going? Cry about it?
         end
       end
 

--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -93,6 +93,7 @@ module Conduit
     end
 
     def subscribe(responder_type, **responder_options)
+      raise StandardError.new("Responder must implement process_conduit_response") unless responder_type.respond_to?(:process_conduit_response)
       self.subscriptions.create(responder_type: responder_type.to_s, responder_options: responder_options)
     end
 

--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -144,7 +144,7 @@ module Conduit
         return unless last_response = responses.last
         subscriptions.each do |subscription|
           subscription.handle_conduit_response(action, last_response)
-          # What to do if one of them fail? Keep going? Cry about it?
+          # TODO Deal with failures here (at least determine the behavior if one of them throws an exception)
         end
       end
 

--- a/app/models/conduit/response.rb
+++ b/app/models/conduit/response.rb
@@ -16,17 +16,16 @@ module Conduit
 
     # Hooks
 
-    after_create :report_response_status
+    after_commit :report_response_status, on: :create
 
     # Methods
 
-    delegate :driver, :action, to: :request
+    delegate :subscribers, :callback_subscribers, :callback_url, :driver, :action, to: :request
 
     # Raw access to the parser instance
     #
     def parsed_content
-      @parsed_content ||= Conduit::Util.find_driver(driver, action, 'parser').
-        new(content)
+      @parsed_content ||= Conduit::Util.find_driver(driver, action, 'parser').new(content)
     end
 
     private

--- a/app/models/conduit/subscription.rb
+++ b/app/models/conduit/subscription.rb
@@ -8,5 +8,16 @@ module Conduit
     belongs_to :subscriber, polymorphic: true
     belongs_to :request, class_name: 'Conduit::Request'
 
+    serialize :responder_options, Hash
+
+    def handle_conduit_response(action, response)
+      if responder_type
+        responder = responder_type.constantize
+        if responder && responder.respond_to?(:process_conduit_response)
+          responder.process_conduit_response(action, response, responder_options)
+        end
+      end
+    end
+
   end
 end

--- a/app/models/conduit/subscription.rb
+++ b/app/models/conduit/subscription.rb
@@ -8,8 +8,6 @@ module Conduit
     belongs_to :subscriber, polymorphic: true
     belongs_to :request, class_name: 'Conduit::Request'
 
-    serialize :responder_options, Hash
-
     def handle_conduit_response(action, response)
       if responder_type
         responder = responder_type.constantize

--- a/db/migrate/20150417133935_add_responder_to_conduit_subscription.rb
+++ b/db/migrate/20150417133935_add_responder_to_conduit_subscription.rb
@@ -1,6 +1,6 @@
 class AddResponderToConduitSubscription < ActiveRecord::Migration
   def change
     add_column :conduit_subscriptions, :responder_type, :string
-    add_column :conduit_subscriptions, :responder_options, :text
+    add_column :conduit_subscriptions, :responder_options, :json
   end
 end

--- a/db/migrate/20150417133935_add_responder_to_conduit_subscription.rb
+++ b/db/migrate/20150417133935_add_responder_to_conduit_subscription.rb
@@ -1,0 +1,6 @@
+class AddResponderToConduitSubscription < ActiveRecord::Migration
+  def change
+    add_column :conduit_subscriptions, :responder_type, :string
+    add_column :conduit_subscriptions, :responder_options, :text
+  end
+end

--- a/lib/conduit-rails/version.rb
+++ b/lib/conduit-rails/version.rb
@@ -1,3 +1,3 @@
 module ConduitRails
-  VERSION = '0.1.4'
+  VERSION = '0.2.0'
 end

--- a/lib/conduit-rails/version.rb
+++ b/lib/conduit-rails/version.rb
@@ -1,3 +1,3 @@
 module ConduitRails
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/lib/conduit/acts_as_conduit_subscriber.rb
+++ b/lib/conduit/acts_as_conduit_subscriber.rb
@@ -20,19 +20,6 @@ module Conduit
     # is called on an ActiveRecord Model
     #
     module LocalInstanceMethods
-
-      # Fire this method after the last conduit
-      # request has been updated
-      #
-      # NOTE: This could probably be better
-      #       handled by observers, or a
-      #       custom callback.
-      #
-      def after_conduit_update(action, parsed_response)
-        # This method should be overriden
-        # on the requestable object
-      end
-
     end
 
   end

--- a/spec/classes/acts_as_conduit_subscriber_spec.rb
+++ b/spec/classes/acts_as_conduit_subscriber_spec.rb
@@ -5,12 +5,6 @@ require 'spec_helper'
 class MySubscriber < ActiveRecord::Base
   acts_as_conduit_subscriber
 
-  # Update the `updated_at` timestamp
-  # so we know this has been called
-  #
-  def after_conduit_update(action, parsed_response)
-    self.update_column(:updated_at, 1.day.from_now)
-  end
 end
 
 describe MySubscriber do
@@ -48,14 +42,6 @@ describe MySubscriber do
       @obj.conduit_requests.create(driver: :my_driver, action: :foo,
         options: request_attributes).perform_request
     end
-
-    describe '#after_conduit_update' do
-      it 'gets called after a request is updated' do
-        @obj.reload # Bust the cache
-        @obj.updated_at.should_not == @obj.created_at
-      end
-    end
-
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140305202729) do
+ActiveRecord::Schema.define(version: 20150417133935) do
 
   create_table "conduit_requests", force: true do |t|
     t.string   "driver"
@@ -38,6 +38,8 @@ ActiveRecord::Schema.define(version: 20140305202729) do
     t.string   "subscriber_type"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "responder_type"
+    t.text     "responder_options"
   end
 
   add_index "conduit_subscriptions", ["request_id"], name: "index_conduit_subscriptions_on_request_id"

--- a/spec/models/conduit/request_spec.rb
+++ b/spec/models/conduit/request_spec.rb
@@ -47,4 +47,19 @@ describe Conduit::Request do
     end
   end
 
+  context "with a subscriber" do
+    let (:subscription) { Conduit::Subscription.new }
+    let (:response) { subject.responses.create(content: "some content") }
+
+    before :each do
+      subject.subscriptions << subscription
+    end
+
+    it "it notifies the subscriber with response" do
+      expect(subscription).to receive(:handle_conduit_response).with(subject.action, response)
+      subject.save
+    end
+
+  end
+
 end

--- a/spec/models/conduit/subscription_spec.rb
+++ b/spec/models/conduit/subscription_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'pry'
+
+describe Conduit::Subscription do
+
+  let (:action) { "action" }
+  let (:response) { "response" }
+
+  context "when a response comes back with responder" do
+
+    class TestResponder
+      def self.process_conduit_response(action, response, options)
+      end
+    end
+
+    let (:responder_options) { {some_parameter: 1} }
+    subject { Conduit::Subscription.new(responder_type: TestResponder.to_s, responder_options: responder_options)}
+
+    it "calls process_conduit_response on the responder" do
+      expect(TestResponder).to receive(:process_conduit_response).with(action, response, responder_options)
+      subject.handle_conduit_response(action, response)
+    end
+  end
+
+end


### PR DESCRIPTION
This allows subscriptions to not require an ActiveRecord object, but instead take class and options. The change was made so that a response could be handled from a separate object that was not the object that initiated the request.