### PR TITLE
Atom compat

### DIFF
--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -144,7 +144,7 @@ module Conduit
         return unless should_notify_subscribers?
         return unless last_response = responses.last
 
-        to_notify = (subscriptions + (self.respond_to?(:subscribers) ? subscribers : [])).uniq
+        to_notify = (subscriptions + (self.respond_to?(:subscribers) ? subscribers : [])).uniq.compact
         to_notify.each do |subscription|
           with_logged_exceptions do
             subscription.handle_conduit_response(action, last_response)

--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -144,7 +144,8 @@ module Conduit
         return unless should_notify_subscribers?
         return unless last_response = responses.last
 
-        subscriptions.each do |subscription|
+        to_notify = (subscriptions + (self.respond_to?(:subscribers) ? subscribers : [])).uniq
+        to_notify.each do |subscription|
           with_logged_exceptions do
             subscription.handle_conduit_response(action, last_response)
           end

--- a/lib/conduit-rails/version.rb
+++ b/lib/conduit-rails/version.rb
@@ -1,3 +1,3 @@
 module ConduitRails
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
This makes the subscription notification use "subscriptions" (the new way) or "subscribers" (the old way), if the model supports it.

This lets use use the same version for Atom and Reactor, but we should think about making them both use the same technique, at some point.