### PR TITLE
atom need subscribers to answer to after_conduit_update all the time

### DIFF
--- a/lib/conduit/acts_as_conduit_subscriber.rb
+++ b/lib/conduit/acts_as_conduit_subscriber.rb
@@ -20,7 +20,12 @@ module Conduit
     # is called on an ActiveRecord Model
     #
     module LocalInstanceMethods
+       def after_conduit_update(action, parsed_response)
+         # this is used to know if we're making a stand-alone or a attached request in atom
+       end
+
     end
+
 
   end
 end


### PR DESCRIPTION
Turns out we need anything that's a conduit subscriber to respond to after_conduit_update for the subscription to be attached.