### PR TITLE
This adds a transaction ID to the request.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    conduit-rails (0.2.2)
+    conduit-rails (0.2.3)
       conduit (> 0.5.2)
       rails
+      request_store (~> 1.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -35,17 +36,15 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
-    aws-sdk (2.0.39)
-      aws-sdk-resources (= 2.0.39)
-    aws-sdk-core (2.0.39)
-      builder (~> 3.0)
+    aws-sdk (2.2.3)
+      aws-sdk-resources (= 2.2.3)
+    aws-sdk-core (2.2.3)
       jmespath (~> 1.0)
-      multi_json (~> 1.0)
-    aws-sdk-resources (2.0.39)
-      aws-sdk-core (= 2.0.39)
+    aws-sdk-resources (2.2.3)
+      aws-sdk-core (= 2.2.3)
     builder (3.2.2)
     coderay (1.1.0)
-    conduit (0.6.0)
+    conduit (0.6.3)
       activesupport
       aws-sdk
       excon
@@ -53,10 +52,9 @@ GEM
     database_cleaner (1.2.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    excon (0.45.2)
+    excon (0.45.4)
     i18n (0.6.11)
-    jmespath (1.0.2)
-      multi_json (~> 1.0)
+    jmespath (1.1.3)
     json (1.8.1)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -64,7 +62,6 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.4.1)
-    multi_json (1.11.0)
     polyglot (0.3.5)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -89,6 +86,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
+    request_store (1.2.1)
     rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -104,9 +102,9 @@ GEM
     shoulda-matchers (2.6.1)
       activesupport (>= 3.0.0)
     slop (3.6.0)
-    sprockets (3.0.1)
-      rack (~> 1.0)
-    sprockets-rails (2.2.4)
+    sprockets (3.4.1)
+      rack (> 1, < 3)
+    sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)

--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -102,7 +102,9 @@ module Conduit
     private
 
     def set_transaction_id
-      self.transaction_id ||= RequestStore.store[:transaction_id] || Thread.current[:transaction_id]
+      if respond_to? :transaction_id
+        self.transaction_id ||= RequestStore.store[:transaction_id] || Thread.current[:transaction_id]
+      end
       true
     end
 

--- a/app/models/conduit/request.rb
+++ b/app/models/conduit/request.rb
@@ -27,6 +27,8 @@ module Conduit
     after_initialize  :set_defaults
     after_commit      :notify_subscribers, on: [:update]
 
+    before_save       :set_transaction_id, on: [:create]
+
     # Scopes
 
     scope :by_action, -> (actions) { where(action: actions) }
@@ -99,77 +101,83 @@ module Conduit
 
     private
 
-      def conduit_driver
-        @conduit_driver ||= Conduit::Util.find_driver(driver)
+    def set_transaction_id
+      self.transaction_id ||= RequestStore.store[:transaction_id] || Thread.current[:transaction_id]
+      true
+    end
+
+
+    def conduit_driver
+      @conduit_driver ||= Conduit::Util.find_driver(driver)
+    end
+
+    def assure_supported_driver_and_action
+      unless conduit_driver.present?
+        errors.add(:driver, "#{driver} is not a supported driver")
+        return false
       end
 
-      def assure_supported_driver_and_action
-        unless conduit_driver.present?
-          errors.add(:driver, "#{driver} is not a supported driver")
-          return false
-        end
-
-        unless conduit_driver.actions.include?(action.to_sym)
-          errors.add(:action, "not supported by the #{driver} driver")
-          return false
-        end
+      unless conduit_driver.actions.include?(action.to_sym)
+        errors.add(:action, "not supported by the #{driver} driver")
+        return false
       end
+    end
 
 
 
-      # Set some default values
-      #
-      def set_defaults
-        self.status ||= 'open'
-      end
+    # Set some default values
+    #
+    def set_defaults
+      self.status ||= 'open'
+    end
 
-      def connection_error?
-        %w(timeout error).include?(status.to_s)
-      end
+    def connection_error?
+      %w(timeout error).include?(status.to_s)
+    end
 
-      # Generate a unique storage key
-      # TODO: Dynamic File Format
-      #
-      def generate_storage_path
-        update_column(:file, File.join("#{id}".reverse!,
-          driver.to_s, action.to_s, 'request.xml'))
-      end
+    # Generate a unique storage key
+    # TODO: Dynamic File Format
+    #
+    def generate_storage_path
+      update_column(:file, File.join("#{id}".reverse!,
+                                     driver.to_s, action.to_s, 'request.xml'))
+    end
 
-      # Notify the requestable that our status
-      # has changed. This is done by calling
-      # a predefined method name on the
-      # requestable instance
-      #
-      def notify_subscribers
-        return unless should_notify_subscribers?
-        return unless last_response = responses.last
+    # Notify the requestable that our status
+    # has changed. This is done by calling
+    # a predefined method name on the
+    # requestable instance
+    #
+    def notify_subscribers
+      return unless should_notify_subscribers?
+      return unless last_response = responses.last
 
-        to_notify = (subscriptions + (self.respond_to?(:subscribers) ? subscribers : [])).uniq.compact
-        to_notify.each do |subscription|
-          with_logged_exceptions do
-            subscription.handle_conduit_response(action, last_response)
-          end
-        end
-      end
-
-      # Raw access to the action instance
-      #
-      def raw
-        @raw ||= Conduit::Util.find_driver(driver,
-          action).new(options.symbolize_keys!)
-      end
-
-      def should_notify_subscribers?
-        !connection_error? && previous_changes.include?(:status)
-      end
-
-      def with_logged_exceptions(&block)
-        begin
-          yield
-        rescue StandardError => e
-          Rails.logger.error e.message
-          Rails.logger.error e.backtrace.join("\n")
+      to_notify = (subscriptions + (self.respond_to?(:subscribers) ? subscribers : [])).uniq.compact
+      to_notify.each do |subscription|
+        with_logged_exceptions do
+          subscription.handle_conduit_response(action, last_response)
         end
       end
+    end
+
+    # Raw access to the action instance
+    #
+    def raw
+      @raw ||= Conduit::Util.find_driver(driver,
+                                         action).new(options.symbolize_keys!)
+    end
+
+    def should_notify_subscribers?
+      !connection_error? && previous_changes.include?(:status)
+    end
+
+    def with_logged_exceptions(&block)
+      begin
+        yield
+      rescue StandardError => e
+        Rails.logger.error e.message
+        Rails.logger.error e.backtrace.join("\n")
+      end
+    end
   end
 end

--- a/conduit-rails.gemspec
+++ b/conduit-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # Dependencies
   #
   s.add_dependency 'conduit', '> 0.5.2'
-  s.add_dependency 'request_store', '~> 1.2.0'
+  s.add_dependency 'request_store', '~> 1'
   s.add_dependency 'rails'
 
   # Development Dependencies

--- a/conduit-rails.gemspec
+++ b/conduit-rails.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   # Dependencies
   #
   s.add_dependency 'conduit', '> 0.5.2'
+  s.add_dependency 'request_store', '~> 1.2.0'
   s.add_dependency 'rails'
 
   # Development Dependencies

--- a/db/migrate/20151201151542_add_txn_id_to_request.rb
+++ b/db/migrate/20151201151542_add_txn_id_to_request.rb
@@ -1,0 +1,5 @@
+class AddTxnIdToRequest < ActiveRecord::Migration
+  def change
+    add_column :conduit_requests, :transaction_id, :string
+  end
+end

--- a/lib/conduit-rails/version.rb
+++ b/lib/conduit-rails/version.rb
@@ -1,3 +1,3 @@
 module ConduitRails
-  VERSION = '0.2.3'
+  VERSION = '1.0.0'
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150417133935) do
+ActiveRecord::Schema.define(version: 20151201151542) do
 
   create_table "conduit_requests", force: true do |t|
     t.string   "driver"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 20150417133935) do
     t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "last_error_message"
+    t.string   "transaction_id"
   end
 
   create_table "conduit_responses", force: true do |t|

--- a/spec/models/conduit/request_spec.rb
+++ b/spec/models/conduit/request_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'request_store'
 
 describe Conduit::Request do
 
@@ -28,6 +29,13 @@ describe Conduit::Request do
 
     it "creates a response in the database" do
       subject.responses.should_not be_empty
+    end
+
+    it "perserves the transaction id" do
+      RequestStore.store[:transaction_id] = "foo"
+      req = Conduit::Request.create(driver: :my_driver, action: :foo,
+        options: request_attributes)
+      expect(req.transaction_id).to eq("foo")
     end
   end
 


### PR DESCRIPTION
This is the second part of having a transaction ID that goes though our
whole stack. This will let us trace the cause of requests, and their
consequences, and will hopefully make it easy for us to do things like
ascribe actions that reactor carries out to users in atom.