### PR TITLE
rev up to remove a change to callbacks.

### DIFF
--- a/app/models/conduit/concerns/storage.rb
+++ b/app/models/conduit/concerns/storage.rb
@@ -6,7 +6,7 @@ module Conduit
       included do
         attr_writer :content
 
-        after_commit  :add_to_storage, on: :create, if: :generate_storage_path
+        after_create  :add_to_storage,      if: :generate_storage_path
         after_destroy :remove_from_storage, if: :file
       end
 

--- a/lib/conduit-rails/version.rb
+++ b/lib/conduit-rails/version.rb
@@ -1,3 +1,3 @@
 module ConduitRails
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end


### PR DESCRIPTION
This change was meant to be cooridinated with a connect-api PR that never
 happened. The existing code breaks with v1.0.4